### PR TITLE
feat: add touchscreen gesture and ASUS Pen mapping configuration for GNOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A script to manage features on the Zenbook Duo.
 | Auto rotation | ✅ | |
 | Keyboard backlight when keyboard off | | ❌ |
 | Keyboard function keys (some work in BT mode) | | ❌ |
+| Pen and Touch Input on second screen (before input on second screen mapped to main screen only) | ✅ | |
 
 ## Tested on
 

--- a/setup.sh
+++ b/setup.sh
@@ -103,11 +103,15 @@ if gnome_session_active; then
         echo "Error: dconf is not available. Install dconf-cli and re-run setup.sh to apply gesture mapping." >&2
     fi
     if command -v dconf &>/dev/null; then
-        dconf write "/org/gnome/desktop/peripherals/touchscreens/04f3:4447/output" "['SDC', '0x419d', '0x00000000', 'eDP-1']"
-        dconf write "/org/gnome/desktop/peripherals/touchscreens/04f3:4448/output" "['SDC', '0x419d', '0x00000000', 'eDP-2']"
-        dconf write "/org/gnome/desktop/peripherals/tablets/04f3:4447/output" "['SDC', '0x419d', '0x00000000', 'eDP-1']"
-        dconf write "/org/gnome/desktop/peripherals/tablets/04f3:4448/output" "['SDC', '0x419d', '0x00000000', 'eDP-2']"
-        echo "Gesture and pen mapping configured: digitizer on main screen -> eDP-1, digitizer on second screen -> eDP-2."
+        if dconf write "/org/gnome/desktop/peripherals/touchscreens/04f3:4447/output" "['SDC', '0x419d', '0x00000000', 'eDP-1']" \
+            && dconf write "/org/gnome/desktop/peripherals/touchscreens/04f3:4448/output" "['SDC', '0x419d', '0x00000000', 'eDP-2']" \
+            && dconf write "/org/gnome/desktop/peripherals/tablets/04f3:4447/output" "['SDC', '0x419d', '0x00000000', 'eDP-1']" \
+            && dconf write "/org/gnome/desktop/peripherals/tablets/04f3:4448/output" "['SDC', '0x419d', '0x00000000', 'eDP-2']"; then
+            echo "Gesture and pen mapping configured: digitizer on main screen -> eDP-1, digitizer on second screen -> eDP-2."
+        else
+            echo "Error: failed to write one or more GNOME dconf mappings." >&2
+            echo "Run setup.sh again in an active GNOME session, or apply keys manually with dconf write." >&2
+        fi
     fi
 else
     echo "Non-GNOME desktop detected. Skipping gesture mapping configuration."

--- a/setup.sh
+++ b/setup.sh
@@ -82,4 +82,15 @@ systemctl --user daemon-reexec
 systemctl --user daemon-reload
 sudo systemctl --global enable zenbook-duo-user.service
 
+if [ "${XDG_CURRENT_DESKTOP}" = "GNOME" ] || [ "${DESKTOP_SESSION}" = "gnome" ] || command -v gnome-shell &>/dev/null; then
+    echo "GNOME detected. Configuring touchscreen gesture mapping..."
+    dconf write "/org/gnome/desktop/peripherals/touchscreens/04f3:4447/output" "['SDC', '0x419d', '0x00000000', 'eDP-1']"
+    dconf write "/org/gnome/desktop/peripherals/touchscreens/04f3:4448/output" "['SDC', '0x419d', '0x00000000', 'eDP-2']"
+    dconf write "/org/gnome/desktop/peripherals/tablets/04f3:4447/output" "['SDC', '0x419d', '0x00000000', 'eDP-1']"
+    dconf write "/org/gnome/desktop/peripherals/tablets/04f3:4448/output" "['SDC', '0x419d', '0x00000000', 'eDP-2']"
+    echo "Gesture and pen mapping configured: digitizer on main screen -> eDP-1, digitizer on second screen -> eDP-2."
+else
+    echo "Non-GNOME desktop detected. Skipping gesture mapping configuration."
+fi
+
 echo "Install complete."

--- a/setup.sh
+++ b/setup.sh
@@ -21,7 +21,8 @@ if [ "${DEV_MODE}" = false ]; then
         usbutils \
         mutter-common-bin \
         iio-sensor-proxy \
-        python3-usb
+        python3-usb \
+        dconf-cli
     sudo mkdir -p /usr/local/bin
     sudo cp ./duo.sh ${INSTALL_LOCATION}
     sudo chmod a+x ${INSTALL_LOCATION}
@@ -69,7 +70,6 @@ After=graphical-session.target
 ExecStartPre=/bin/sleep 3
 ExecStart=${INSTALL_LOCATION}
 Restart=no
-Environment=XDG_CURRENT_DESKTOP=GNOME
 
 [Install]
 WantedBy=default.target
@@ -82,13 +82,33 @@ systemctl --user daemon-reexec
 systemctl --user daemon-reload
 sudo systemctl --global enable zenbook-duo-user.service
 
-if [ "${XDG_CURRENT_DESKTOP}" = "GNOME" ] || [ "${DESKTOP_SESSION}" = "gnome" ] || command -v gnome-shell &>/dev/null; then
+# Returns 0 only when the *current session* is GNOME.
+# Checks session env vars first; falls back to a running gnome-shell process.
+# Avoids false positives from 'command -v gnome-shell', which only tests whether
+# GNOME is installed, not whether it is the active desktop session.
+gnome_session_active() {
+    # XDG_CURRENT_DESKTOP can be a colon-separated list (e.g. "ubuntu:GNOME")
+    case ":${XDG_CURRENT_DESKTOP}:" in *:GNOME:*) return 0 ;; esac
+    # XDG_SESSION_DESKTOP is set by the session manager to the session name
+    case "${XDG_SESSION_DESKTOP}" in gnome|GNOME|gnome-xorg|gnome-wayland) return 0 ;; esac
+    # Legacy / distro-specific fallback
+    case "${DESKTOP_SESSION}" in gnome|GNOME|gnome-xorg|gnome-wayland) return 0 ;; esac
+    # Last resort: a running gnome-shell process means GNOME is the active session
+    pgrep -x gnome-shell &>/dev/null
+}
+
+if gnome_session_active; then
     echo "GNOME detected. Configuring touchscreen gesture mapping..."
-    dconf write "/org/gnome/desktop/peripherals/touchscreens/04f3:4447/output" "['SDC', '0x419d', '0x00000000', 'eDP-1']"
-    dconf write "/org/gnome/desktop/peripherals/touchscreens/04f3:4448/output" "['SDC', '0x419d', '0x00000000', 'eDP-2']"
-    dconf write "/org/gnome/desktop/peripherals/tablets/04f3:4447/output" "['SDC', '0x419d', '0x00000000', 'eDP-1']"
-    dconf write "/org/gnome/desktop/peripherals/tablets/04f3:4448/output" "['SDC', '0x419d', '0x00000000', 'eDP-2']"
-    echo "Gesture and pen mapping configured: digitizer on main screen -> eDP-1, digitizer on second screen -> eDP-2."
+    if ! command -v dconf &>/dev/null; then
+        echo "Error: dconf is not available. Install dconf-cli and re-run setup.sh to apply gesture mapping." >&2
+    fi
+    if command -v dconf &>/dev/null; then
+        dconf write "/org/gnome/desktop/peripherals/touchscreens/04f3:4447/output" "['SDC', '0x419d', '0x00000000', 'eDP-1']"
+        dconf write "/org/gnome/desktop/peripherals/touchscreens/04f3:4448/output" "['SDC', '0x419d', '0x00000000', 'eDP-2']"
+        dconf write "/org/gnome/desktop/peripherals/tablets/04f3:4447/output" "['SDC', '0x419d', '0x00000000', 'eDP-1']"
+        dconf write "/org/gnome/desktop/peripherals/tablets/04f3:4448/output" "['SDC', '0x419d', '0x00000000', 'eDP-2']"
+        echo "Gesture and pen mapping configured: digitizer on main screen -> eDP-1, digitizer on second screen -> eDP-2."
+    fi
 else
     echo "Non-GNOME desktop detected. Skipping gesture mapping configuration."
 fi


### PR DESCRIPTION

## Summary
This PR adds GNOME-specific input mapping in setup.sh to correctly bind touchscreen and pen input to each physical display on Zenbook Duo 2025 systems.

## What changed
1. Added GNOME desktop detection in setup.sh by checking desktop environment variables and falling back to gnome-shell presence.
2. When GNOME is detected, the script now writes display mappings through dconf for both touchscreen and tablet input paths:
   - Device 04f3:4447 mapped to eDP-1
   - Device 04f3:4448 mapped to eDP-2
3. Added clear runtime messages indicating:
   - whether GNOME was detected
   - whether input mapping was applied or skipped

## Why this change
On Zenbook Duo 2025, touch input and Asus Pen 2.0 input from the second screen were being routed to the top screen.  
This update fixes that behavior by explicitly mapping each ELAN digitizer to its corresponding display in GNOME.

## Technical note
Asus Pen 2.0 uses the same ELAN digitizer IDs as the touchscreens:
- 04f3:4447 for eDP-1
- 04f3:4448 for eDP-2

Because GNOME tracks tablet/pen devices separately from touch devices, applying equivalent mappings under GNOME tablet dconf paths ensures the pen on the second screen correctly maps to eDP-2.

## Result
Touch and pen input now align with the correct screen under GNOME, and non-GNOME environments are left unchanged.

This should also fix #1 